### PR TITLE
Add ability to register mappers

### DIFF
--- a/app/propertyDatabases/__tests__/greenField.test.ts
+++ b/app/propertyDatabases/__tests__/greenField.test.ts
@@ -26,8 +26,8 @@ test('non-missing property will not use default', async () => {
   expect(config.get('foo.bar').asString('default')).toBe('5');
   expect(config.get('foo.bar').asNumber(10)).toBe(5);
   expect(config.get('foo').asObject({ bazz: '10' })).toEqual({ bar: '5' });
-  expect(config.get('foo').asMapped(obj => parseInt(obj.bar), '10')).toBe(5);
-  expect(config.get('foo').mapToArray((key, obj) => obj, ['10'])).toEqual(['5']);
+  expect(config.get('foo').asMapped(obj => parseInt(obj.bar), 10)).toBe(5);
+  expect(config.get('foo').asMappedArray((key, obj) => obj, ['10'])).toEqual(['5']);
 });
 
 test('missing property can be defaulted', async () => {
@@ -39,7 +39,7 @@ test('missing property can be defaulted', async () => {
   expect(config.get('bar').asNumber(5)).toBe(5);
   expect(config.get('bar').asObject({ bar: '5' })).toEqual({ bar: '5' });
   expect(config.get('bar').asMapped(echo => echo, '5')).toBe('5');
-  expect(config.get('bar').mapToArray((key, obj) => obj, ['5'])).toEqual(['5']);
+  expect(config.get('bar').asMappedArray((key, obj) => obj, ['5'])).toEqual(['5']);
 });
 
 test('missing property with no default throws error', async () => {
@@ -51,7 +51,7 @@ test('missing property with no default throws error', async () => {
   expect(() => config.get('bar').asNumber()).toThrow();
   expect(() => config.get('bar').asObject()).toThrow();
   expect(() => config.get('bar').asMapped(echo => echo)).toThrow();
-  expect(() => config.get('bar').mapToArray((key, obj) => obj)).toThrow();
+  expect(() => config.get('bar').asMappedArray((key, obj) => obj)).toThrow();
 });
 
 test('multiple properties dont collide', async () => {

--- a/app/propertyDatabases/__tests__/mappers.test.ts
+++ b/app/propertyDatabases/__tests__/mappers.test.ts
@@ -1,0 +1,112 @@
+import { PropertyDatabase } from '../propertyDatabase';
+import { EnvironmentPropertyLoader } from '../../propertyLoaders/environmentPropertyLoader';
+import { StaticPropertyLoader } from '../../propertyLoaders/staticPropertyLoader';
+
+class Foo {
+  constructor(public bar: number) {}
+
+  static map(obj: any): Foo {
+    return new Foo(parseInt(obj.bar));
+  }
+}
+
+class FooNew {
+  constructor(public bar: string) {}
+
+  static map(obj: any): Foo {
+    return new Foo(obj.bar);
+  }
+}
+
+class ArrayFoo {
+  constructor(public name: string, public bar: number) {}
+
+  static arrayMap(name: string, obj: any): ArrayFoo {
+    return new ArrayFoo(name, parseInt(obj.bar));
+  }
+}
+
+class ArrayFooNew {
+  constructor(public name: string, public bar: string) {}
+
+  static arrayMap(name: string, obj: any): ArrayFoo {
+    return new ArrayFoo(name, obj.bar);
+  }
+}
+
+test('registered mapper can be used', async () => {
+  let config: PropertyDatabase = new PropertyDatabase([]);
+  config.withPropertyLoader(new StaticPropertyLoader({ foo: { bar: 5 } }));
+  config.registerMapper('foo', Foo.map);
+  await config.loadProperties();
+  expect(config.get('foo').asMapped()).toEqual(new Foo(5));
+});
+
+test('no registered mapper will use passed in mapper', async () => {
+  let config: PropertyDatabase = new PropertyDatabase([]);
+  config.withPropertyLoader(new StaticPropertyLoader({ foo: { bar: 5 } }));
+  await config.loadProperties();
+  expect(config.get('foo').asMapped(Foo.map)).toEqual(new Foo(5));
+});
+
+test('no registered mapper, and no passed will throw', async () => {
+  let config: PropertyDatabase = new PropertyDatabase([]);
+  config.withPropertyLoader(new StaticPropertyLoader({ foo: { bar: 5 } }));
+  await config.loadProperties();
+  expect(() => config.get('foo').asMapped()).toThrow();
+});
+
+test('registered arrayMapper can be used', async () => {
+  let config: PropertyDatabase = new PropertyDatabase([]);
+  config.withPropertyLoader(
+    new StaticPropertyLoader({ foo: { test1: { bar: 5 }, test2: { bar: 6 } } })
+  );
+  config.registerArrayMapper('foo', ArrayFoo.arrayMap);
+  await config.loadProperties();
+  expect(config.get('foo').asMappedArray()).toEqual([
+    new ArrayFoo('test1', 5),
+    new ArrayFoo('test2', 6),
+  ]);
+});
+
+test('no registered arrayMapper will use passed in mapper', async () => {
+  let config: PropertyDatabase = new PropertyDatabase([]);
+  config.withPropertyLoader(
+    new StaticPropertyLoader({ foo: { test1: { bar: 5 }, test2: { bar: 6 } } })
+  );
+  await config.loadProperties();
+  expect(config.get('foo').asMappedArray(ArrayFoo.arrayMap)).toEqual([
+    new ArrayFoo('test1', 5),
+    new ArrayFoo('test2', 6),
+  ]);
+});
+
+test('no registered arrayMapper, and no passed will throw', async () => {
+  let config: PropertyDatabase = new PropertyDatabase([]);
+  config.withPropertyLoader(
+    new StaticPropertyLoader({ foo: { test1: { bar: 5 }, test2: { bar: 6 } } })
+  );
+  await config.loadProperties();
+  expect(() => config.get('foo').asMappedArray()).toThrow();
+});
+
+test('registered mapper can be overridden', async () => {
+  let config: PropertyDatabase = new PropertyDatabase([]);
+  config.withPropertyLoader(new StaticPropertyLoader({ foo: { bar: 5 } }));
+  config.registerMapper('foo', Foo.map);
+  await config.loadProperties();
+  expect(config.get('foo').asMapped(FooNew.map)).toEqual(new FooNew('5'));
+});
+
+test('registered arrayMapper can be overridden', async () => {
+  let config: PropertyDatabase = new PropertyDatabase([]);
+  config.withPropertyLoader(
+    new StaticPropertyLoader({ foo: { test1: { bar: 5 }, test2: { bar: 6 } } })
+  );
+  config.registerArrayMapper('foo', ArrayFoo.arrayMap);
+  await config.loadProperties();
+  expect(config.get('foo').asMappedArray(ArrayFooNew.arrayMap)).toEqual([
+    new ArrayFooNew('test1', '5'),
+    new ArrayFooNew('test2', '6'),
+  ]);
+});

--- a/app/propertyDatabases/mapper.ts
+++ b/app/propertyDatabases/mapper.ts
@@ -1,0 +1,2 @@
+export type Mapper<T> = (obj: any) => T;
+export type ArrayMapper<T> = (key: string, obj: any) => T;

--- a/app/propertyDatabases/propertyDatabase.ts
+++ b/app/propertyDatabases/propertyDatabase.ts
@@ -2,6 +2,7 @@ import { PropertyMeta } from '../property';
 import { PropertyLoader } from '../propertyLoaders/propertyLoader';
 import { PropertySource } from '../propertySources/propertySource';
 import { PropertyContext } from './propertyContext';
+import { Mapper, ArrayMapper } from './mapper';
 
 export interface DatabaseOptions {
   logger?: DatabaseLogger;
@@ -23,6 +24,8 @@ export class PropertyDatabase {
   private hasLoaded: boolean = false;
   private logger: DatabaseLogger;
   private profiles: string[];
+  private mappers: { [key: string]: Mapper<any> };
+  private arrayMappers: { [key: string]: ArrayMapper<any> };
 
   constructor(profiles?: string[], private options?: DatabaseOptions) {
     this.logger = {
@@ -34,6 +37,8 @@ export class PropertyDatabase {
     }
     this.profiles = profiles || [];
     this.loaders = [];
+    this.mappers = {};
+    this.arrayMappers = {};
   }
 
   use(loader: PropertyLoader): void {
@@ -95,7 +100,15 @@ export class PropertyDatabase {
       );
     }
 
-    return new PropertyContext(key, this.properties);
+    return new PropertyContext(key, this.properties, this.mappers[key], this.arrayMappers[key]);
+  }
+
+  registerMapper<T>(key: string, mapper: Mapper<T>) {
+    this.mappers[key] = mapper;
+  }
+
+  registerArrayMapper<T>(key: string, mapper: ArrayMapper<T>) {
+    this.arrayMappers[key] = mapper;
   }
 
   //TODO allow for property name rewriting


### PR DESCRIPTION
This allows you to register a mapper in one place and call asMapped or asArrayMapped in multiple locations without having to specify the mapper over and over again.

Also change mapToArray to asArrayMapped to be more consistent with the other methods on PropertyContext

@yunruiwatts thoughts?